### PR TITLE
Restore tests that support Python 2

### DIFF
--- a/ci/run-tests.sh
+++ b/ci/run-tests.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -ex
+
+export PIP_CACHE_DIR=`pwd`/pip-cache
+
+perl -pi -e 's/(skip_missing_interpreters) = true/\1 = false/' tox.ini
+tox --recreate

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,44 @@
+[tox]
+envlist = py27,py35,py36,py37,{py27,py35,py36,py37}-flake8,mypy-{py2,py3}
+skip_missing_interpreters = true
+
+[testenv]
+deps =
+    -rrequirements.txt
+    -rrequirements_dev.txt
+commands = nosetests
+
+[testenv:mypy-py2]
+basepython = python3
+skip_install = true
+deps = mypy
+commands = mypy --py2 --ignore-missing-imports mbdata/
+
+[testenv:mypy-py3]
+basepython = python3
+skip_install = true
+deps = mypy
+commands = mypy --ignore-missing-imports mbdata/
+
+[testenv:py27-flake8]
+deps = flake8
+skip_install = true
+commands = python -m flake8 mbdata/
+
+[testenv:py35-flake8]
+deps = flake8
+skip_install = true
+commands = python -m flake8 mbdata/
+
+[testenv:py36-flake8]
+deps = flake8
+skip_install = true
+commands = python -m flake8 mbdata/
+
+[flake8]
+ignore = F401,E501,W391,F405,E128,W291,E126,E121,F403
+per-file-ignores =
+    mbdata/sample_data.py:E501
+    mbdata/models.py:E501
+    mbdata/api/tests/__init__.py:E402
+max-line-length = 160


### PR DESCRIPTION
Picked from https://github.com/yvanzo/mbdata/tree/v26.0.dev4